### PR TITLE
Implement a filesystem-based session

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Example
 -------
 
 ```php
-use web\session\ForTesting;
+use web\session\{InFileSystem, ForTesting};
 
-$sessions= new ForTesting();
+// Instantiate session factory
+$sessions= new InFileSystem('/tmp');
+$sessions= (new ForTesting())->lasting(3600);
 
 // Create a new session
 $session= $sessions->create();

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Sessions",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^9.0 | ^8.0 | ^7.0",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.3",
     "php": ">=5.6.0"
   },
   "require-dev" : {

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -68,8 +68,11 @@ class InFileSystem extends Sessions {
   public function locate($id) {
     $f= new File($this->path->getURI(), $this->prefix.$id);
     if ($f->exists()) {
-      $age= time() - $f->createdAt();
-      return new Session($f, time() + ($this->duration - $age));
+      $created= $f->createdAt();
+      if (time() - $created < $this->duration) {
+        return new Session($f, $created + $this->duration);
+      }
+      $f->unlink();
     }
     return null;
   }

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -40,6 +40,19 @@ class InFileSystem extends Sessions {
     $this->random= new Random();
   }
 
+  /** @return int */
+  public function gc() {
+    $expiry= time() - $this->duration;
+    $deleted= 0;
+    foreach (glob($this->path->getURI().$this->prefix.'*') as $file) {
+      if (filectime($file) >= $expiry) continue;
+
+      unlink($file);
+      $deleted++;
+    }
+    return $deleted;
+  }
+
   /**
    * Creates a session
    *
@@ -52,6 +65,7 @@ class InFileSystem extends Sessions {
     do {
       $f= new File($this->path, $this->prefix.substr($buffer, $offset, 32));
       if (!$f->exists() && $f->touch()) {
+        $this->gc();
         return new Session($f, time() + $this->duration);
       }
     } while ($offset++ < 32);

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -14,15 +14,16 @@ use web\session\filesystem\Session;
  * @test  xp://web.session.unittest.InFileSystemTest
  */
 class InFileSystem extends Sessions {
-  private $path, $random;
+  private $path, $prefix, $random;
 
   /**
    * Creates a new filesystem-based factory
    *
    * @param io.Folder|io.Path|string $path
+   * @param  string $prefix Prefix all files, defaults to "sess_"
    * @throws lang.IllegalArgumentException if the path does not exist or is not writable
    */
-  public function __construct($path= null) {
+  public function __construct($path= null, $prefix= 'sess_') {
     if (null === $path) {
       $this->path= new Folder(Environment::tempDir());
     } else if ($path instanceof Folder) {
@@ -35,6 +36,7 @@ class InFileSystem extends Sessions {
       throw new IllegalArgumentException('Path '.$this->path->getURI().' is not writable');
     }
 
+    $this->prefix= $prefix;
     $this->random= new Random();
   }
 
@@ -48,7 +50,7 @@ class InFileSystem extends Sessions {
     $offset= 0;
 
     do {
-      $f= new File($this->path, 'sess_'.substr($buffer, $offset, 32));
+      $f= new File($this->path, $this->prefix.substr($buffer, $offset, 32));
       if (!$f->exists() && $f->touch()) {
         return new Session($f, time() + $this->duration);
       }
@@ -64,7 +66,7 @@ class InFileSystem extends Sessions {
    * @return web.session.Session
    */
   public function locate($id) {
-    $f= new File($this->path->getURI(), 'sess_'.$id);
+    $f= new File($this->path->getURI(), $this->prefix.$id);
     if ($f->exists()) {
       $age= time() - $f->createdAt();
       return new Session($f, time() + ($this->duration - $age));

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -1,0 +1,50 @@
+<?php namespace web\session;
+
+use web\session\filesystem\Session;
+use io\Folder;
+use io\File;
+use lang\Environment;
+
+/**
+ * Session factory that creates sessions in the local filesystem
+ *
+ * @test  xp://web.session.unittest.InFileSystemTest
+ */
+class InFileSystem extends Sessions {
+  private $path;
+
+  /** @param io.Folder|io.Path|string $path */
+  public function __construct($path= null) {
+    if (null === $path) {
+      $this->path= new Folder(Environment::tempDir());
+    } else if ($path instanceof Folder) {
+      $this->path= $path;
+    } else {
+      $this->path= new Folder($path);
+    }
+  }
+
+  /**
+   * Creates a session
+   *
+   * @return web.session.Session
+   */
+  public function create() {
+    return new Session(new File(tempnam($this->path->getURI(), 'session')), time() + $this->duration);
+  }
+
+  /**
+   * Locates an existing session; returns NULL if there is no such session.
+   *
+   * @param  string $id
+   * @return web.session.Session
+   */
+  public function locate($id) {
+    $f= new File($this->path->getURI(), $id);
+    if ($f->exists()) {
+      $age= time() - $f->createdAt();
+      return new Session($f, time() + ($this->duration - $age));
+    }
+    return null;
+  }
+}

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -25,7 +25,7 @@ class Session implements ISession {
   }
 
   /** @return string */
-  public function id() { return $this->file->getFileName(); }
+  public function id() { return str_replace('sess_', '', $this->file->getFileName()); }
 
   /** @return bool */
   public function valid() { return time() < $this->eol; }
@@ -44,7 +44,7 @@ class Session implements ISession {
    */
   private function open() {
     if (time() >= $this->eol) {
-      throw new SessionInvalid($this->file->getFileName());
+      throw new SessionInvalid($this->id());
     } else if (null !== $this->values) {
       return;
     }

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -101,6 +101,7 @@ class Session implements ISession {
   /** @return void */
   public function destroy() {
     $this->eol= time() - 1;
+    $this->modifications= [];
     $this->file->unlink();
   }
 

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -1,0 +1,144 @@
+<?php namespace web\session\filesystem;
+
+use web\session\ISession;
+use io\File;
+
+/**
+ * A session stored in the filesystem
+ *
+ * @see   xp://web.session.InFileSystem
+ */
+class Session implements ISession {
+  private $file, $eol;
+  private $values= null;
+  private $modifications= [];
+
+  /**
+   * Creates a new file-based session
+   *
+   * @param  string|io.File $file
+   * @param  int eol
+   */
+  public function __construct($file, $eol) {
+    $this->file= $file instanceof File ? $file : new File($file);
+    $this->eol= $eol;
+  }
+
+  /** @return string */
+  public function id() { return $this->file->getFileName(); }
+
+  /** @return bool */
+  public function valid() { return time() < $this->eol; }
+
+  /** @return int */
+  private function size() {
+    clearstatcache(false, $this->file->getURI());
+    return $this->file->size();
+  }
+
+  /**
+   * Open and read underlying file; lazily initalized and cached.
+   *
+   * @return void
+   * @throws web.session.SessionInvalid
+   */
+  private function open() {
+    if (time() >= $this->eol) {
+      throw new SessionInvalid($this->file->getFileName());
+    } else if (null !== $this->values) {
+      return;
+    }
+
+    if (0 === $size= $this->size()) {
+      $this->values= [];
+    } else {
+      $this->file->open(File::READ);
+      $this->file->lockShared();
+      $this->values= unserialize($this->file->read($size));
+      $this->file->unLock();
+      $this->file->close();
+    }
+  }
+
+  /**
+   * Perform a modification
+   * 
+   * @param  string $name
+   * @param  function(string): void $modification
+   * @return void
+   */
+  private function modify($name, $modification) {
+    $this->modifications[$name]= $modification;
+    $modification($name);
+  }
+
+  /** @return void */
+  public function close() {
+    if (empty($this->modifications)) return;
+
+    $this->file->open(File::READWRITE);
+    $this->file->lockExclusive();
+
+    // Read file to ensure we have the most current version of the data
+    if (0 === $size= $this->size()) {
+      $this->values= [];
+    } else {
+      $this->values= unserialize($this->file->read($size));
+      $this->file->seek(0, SEEK_SET);
+    }
+
+    // Replay all modifications, then write back
+    foreach ($this->modifications as $name => $modification) {
+      $modification($name);
+    }
+    $this->modifications= [];
+    $this->file->write(serialize($this->values));
+
+    $this->file->unLock();
+    $this->file->close();
+  }
+
+  /** @return void */
+  public function destroy() {
+    $this->eol= time() - 1;
+    $this->file->unlink();
+  }
+
+  /**
+   * Registers a value - writing it to the session
+   *
+   * @param  string $name
+   * @param  var $value
+   * @return void
+   * @throws web.session.SessionInvalid
+   */
+  public function register($name, $value) {
+    $this->open();
+    $this->modify($name, function($name) use($value) { $this->values[$name]= [$value]; });
+  }
+
+  /**
+   * Retrieves a value - reading it from the session
+   *
+   * @param  string $name
+   * @param  var $default
+   * @return var
+   * @throws web.session.SessionInvalid
+   */
+  public function value($name, $default= null) {
+    $this->open();
+    return isset($this->values[$name]) ? $this->values[$name][0] : $default;
+  }
+
+  /**
+   * Removes a value - deleting it from the session
+   *
+   * @param  string $name
+   * @return void
+   * @throws web.session.SessionInvalid
+   */
+  public function remove($name) {
+    $this->open();
+    $this->modify($name, function() use($name) { unset($this->values[$name]); });
+  }
+}

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -26,14 +26,19 @@ class InFileSystemTest extends TestCase {
   }
 
   #[@test]
+  public function can_create_with_dir() {
+    new InFileSystem(self::$dir);
+  }
+
+  #[@test]
   public function create() {
-    $sessions= new InFileSystem();
+    $sessions= new InFileSystem(self::$dir);
     $this->assertInstanceOf(ISession::class, $sessions->create());
   }
 
   #[@test]
   public function read_write() {
-    $session= (new InFileSystem())->create();
+    $session= (new InFileSystem(self::$dir))->create();
     try {
       $session->register('name', 'value');
       $this->assertEquals('value', $session->value('name'));
@@ -44,7 +49,7 @@ class InFileSystemTest extends TestCase {
 
   #[@test]
   public function read_non_existant() {
-    $session= (new InFileSystem())->create();
+    $session= (new InFileSystem(self::$dir))->create();
     try {
       $this->assertNull($session->value('name'));
     } finally {
@@ -54,7 +59,7 @@ class InFileSystemTest extends TestCase {
 
   #[@test]
   public function read_non_existant_returns_default() {
-    $session= (new InFileSystem())->create();
+    $session= (new InFileSystem(self::$dir))->create();
     try {
       $this->assertEquals('Default value', $session->value('name', 'Default value'));
     } finally {
@@ -64,7 +69,7 @@ class InFileSystemTest extends TestCase {
 
   #[@test]
   public function remove() {
-    $session= (new InFileSystem())->create();
+    $session= (new InFileSystem(self::$dir))->create();
     try {
       $session->register('name', 'value');
       $session->remove('name');
@@ -76,7 +81,7 @@ class InFileSystemTest extends TestCase {
 
   #[@test]
   public function read_write_with_two_session_instances() {
-    $sessions= new InFileSystem();
+    $sessions= new InFileSystem(self::$dir);
 
     $session= $sessions->create();
     $session->register('name', 'value');

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -1,0 +1,91 @@
+<?php namespace web\session\unittest;
+
+use unittest\TestCase;
+use web\session\InFileSystem;
+use web\session\ISession;
+use lang\Environment;
+use io\Folder;
+
+class InFileSystemTest extends TestCase {
+  private static $dir;
+
+  #[@beforeClass]
+  public static function createSessionDir() {
+    self::$dir= new Folder(Environment::tempDir(), uniqid());
+    self::$dir->exists() || self::$dir->create(0777);
+  }
+
+  #[@afterClass]
+  public static function removeSessionDir() {
+    self::$dir->exists() && self::$dir->unlink();
+  }
+
+  #[@test]
+  public function can_create() {
+    new InFileSystem();
+  }
+
+  #[@test]
+  public function create() {
+    $sessions= new InFileSystem();
+    $this->assertInstanceOf(ISession::class, $sessions->create());
+  }
+
+  #[@test]
+  public function read_write() {
+    $session= (new InFileSystem())->create();
+    try {
+      $session->register('name', 'value');
+      $this->assertEquals('value', $session->value('name'));
+    } finally {
+      $session->close();
+    }
+  }
+
+  #[@test]
+  public function read_non_existant() {
+    $session= (new InFileSystem())->create();
+    try {
+      $this->assertNull($session->value('name'));
+    } finally {
+      $session->close();
+    }
+  }
+
+  #[@test]
+  public function read_non_existant_returns_default() {
+    $session= (new InFileSystem())->create();
+    try {
+      $this->assertEquals('Default value', $session->value('name', 'Default value'));
+    } finally {
+      $session->close();
+    }
+  }
+
+  #[@test]
+  public function remove() {
+    $session= (new InFileSystem())->create();
+    try {
+      $session->register('name', 'value');
+      $session->remove('name');
+      $this->assertNull($session->value('name'));
+    } finally {
+      $session->close();
+    }
+  }
+
+  #[@test]
+  public function read_write_with_two_session_instances() {
+    $sessions= new InFileSystem();
+
+    $session= $sessions->create();
+    $session->register('name', 'value');
+    $session->close();
+
+    $session= $sessions->open($session->id());
+    $value= $session->value('name');
+    $session->close();
+
+    $this->assertEquals('value', $value);
+  }
+}

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -5,6 +5,7 @@ use web\session\InFileSystem;
 use web\session\ISession;
 use lang\Environment;
 use io\Folder;
+use lang\IllegalArgumentException;
 
 class InFileSystemTest extends TestCase {
   private static $dir;
@@ -28,6 +29,11 @@ class InFileSystemTest extends TestCase {
   #[@test]
   public function can_create_with_dir() {
     new InFileSystem(self::$dir);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function raises_error_when_non_existant_directory_is_given() {
+    new InFileSystem('@does-not-exist@');
   }
 
   #[@test]

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -106,4 +106,16 @@ class InFileSystemTest extends TestCase {
 
     $this->assertEquals('value', $value);
   }
+
+  #[@test]
+  public function destroy() {
+    $session= (new InFileSystem(self::$dir))->create();
+    try {
+      $session->register('name', 'value');
+      $session->destroy();
+      $this->assertFalse($session->valid());
+    } finally {
+      $session->close();
+    }
+  }
 }

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -43,6 +43,13 @@ class InFileSystemTest extends TestCase {
   }
 
   #[@test]
+  public function session_identifiers_consist_of_32_lowercase_hex_digits() {
+    $sessions= new InFileSystem(self::$dir);
+    $id= $sessions->create()->id();
+    $this->assertTrue((bool)preg_match('/^[a-f0-9]{32}$/i', $id), $id);
+  }
+
+  #[@test]
   public function read_write() {
     $session= (new InFileSystem(self::$dir))->create();
     try {


### PR DESCRIPTION
This pull request implements a session based on the local filesystem.

## Example

```php
$sessions= new InFileSystem();  // Uses system's temp dir ⚠️ 
$sessions= new InFileSystem('/tmp/sessions');

$session= $sessions->create();
$session= $sessions->open($id);

// ... Work with session

$session->close();
```

## Implementation notes

* Uses random bytes from `util.Random` to generate session ID - see xp-framework/core#146 and [how PHP's builtin sessions work](https://github.com/php/php-src/blob/2d48d734a20192a10792669baaa88dbe86f2b3a6/ext/session/session.c#L309)
* Only reads from underlying file if session values are requested
* Only writes to underlying file if session was modified

## Word of caution 

If you pass a world-readable directory, such as /tmp (the default), other users on the server may be able to hijack sessions by getting the list of files in that directory. 

See http://php.net/manual/en/session.configuration.php#ini.session.save-path