### PR TITLE
Tie sessions to request / response

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $sessions= new InFileSystem('/tmp');
 $sessions= (new ForTesting())->lasting(3600);
 
 // Create a new session
-$session= $sessions->create($response);
+$session= $sessions->create();
 
 // Open an existing session
 $session= $sessions->open($request);
@@ -35,7 +35,6 @@ $session->remove('key');
 // Destroy
 $session->destroy();
 
-// Finally, close session. Ensure you always call this - it will take care
-// of synchronizing session values with the underlying storage.
-$session->close();
+// Finally, transmit session to response. Ensure you always call this!
+$session->transmit($response);
 ```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ $sessions= new InFileSystem('/tmp');
 $sessions= (new ForTesting())->lasting(3600);
 
 // Create a new session
-$session= $sessions->create();
+$session= $sessions->create($response);
 
 // Open an existing session
-$session= $sessions->open($id);
+$session= $sessions->open($request);
 
 // ...or, if you'd like to do this conditionally
-if ($session= $sessions->locate($id)) { … }
+if ($session= $sessions->locate($request)) { … }
 
 // Basic I/O operations
 $session->register('key', 'value');

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.3",
+    "xp-forge/web": "^1.0",
     "php": ">=5.6.0"
   },
   "require-dev" : {

--- a/src/main/php/web/session/ForTesting.class.php
+++ b/src/main/php/web/session/ForTesting.class.php
@@ -18,7 +18,7 @@ class ForTesting extends Sessions {
    */
   public function create() {
     $id= uniqid(microtime(true));
-    return $this->sessions[$id]= new Session($this, true, $id, time() + $this->duration);
+    return $this->sessions[$id]= new Session($this, $id, true, time() + $this->duration);
   }
 
   /**
@@ -28,7 +28,7 @@ class ForTesting extends Sessions {
    * @return web.session.Session
    */
   public function locate($request) {
-    $id= $id= $this->id($request);
+    $id= $this->id($request);
     if (isset($this->sessions[$id])) {
       if ($this->sessions[$id]->valid()) return $this->sessions[$id];
       unset($this->sessions[$id]);

--- a/src/main/php/web/session/ForTesting.class.php
+++ b/src/main/php/web/session/ForTesting.class.php
@@ -14,13 +14,11 @@ class ForTesting extends Sessions {
   /**
    * Creates a session
    *
-   * @param  web.Response $response
    * @return web.session.Session
    */
-  public function create($response) {
+  public function create() {
     $id= uniqid(microtime(true));
-    $this->transmit($response, $id);
-    return $this->sessions[$id]= new Session($id, time() + $this->duration);
+    return $this->sessions[$id]= new Session($this, true, $id, time() + $this->duration);
   }
 
   /**

--- a/src/main/php/web/session/ForTesting.class.php
+++ b/src/main/php/web/session/ForTesting.class.php
@@ -14,23 +14,27 @@ class ForTesting extends Sessions {
   /**
    * Creates a session
    *
+   * @param  web.Response $response
    * @return web.session.Session
    */
-  public function create() {
+  public function create($response) {
     $id= uniqid(microtime(true));
+    $this->transmit($response, $id);
     return $this->sessions[$id]= new Session($id, time() + $this->duration);
   }
 
   /**
    * Locates an existing session; returns NULL if there is no such session.
    *
-   * @param  string $id
+   * @param  web.Request $request
    * @return web.session.Session
    */
-  public function locate($id) {
-    if (isset($this->sessions[$id])) {
-      if ($this->sessions[$id]->valid()) return $this->sessions[$id];
-      unset($this->sessions[$id]);
+  public function locate($request) {
+    if ($id= $this->id($request)) {
+      if (isset($this->sessions[$id])) {
+        if ($this->sessions[$id]->valid()) return $this->sessions[$id];
+        unset($this->sessions[$id]);
+      }
     }
     return null;
   }

--- a/src/main/php/web/session/ForTesting.class.php
+++ b/src/main/php/web/session/ForTesting.class.php
@@ -9,7 +9,7 @@ use web\session\testing\Session;
  * @test  xp://web.session.unittest.ForTestingTest
  */
 class ForTesting extends Sessions {
-  private $sessions;
+  private $sessions= [];
 
   /**
    * Creates a session
@@ -28,11 +28,10 @@ class ForTesting extends Sessions {
    * @return web.session.Session
    */
   public function locate($request) {
-    if ($id= $this->id($request)) {
-      if (isset($this->sessions[$id])) {
-        if ($this->sessions[$id]->valid()) return $this->sessions[$id];
-        unset($this->sessions[$id]);
-      }
+    $id= $id= $this->id($request);
+    if (isset($this->sessions[$id])) {
+      if ($this->sessions[$id]->valid()) return $this->sessions[$id];
+      unset($this->sessions[$id]);
     }
     return null;
   }

--- a/src/main/php/web/session/ISession.class.php
+++ b/src/main/php/web/session/ISession.class.php
@@ -17,13 +17,6 @@ interface ISession {
   public function valid();
 
   /**
-   * Closes the session
-   *
-   * @return void
-   */
-  public function close();
-
-  /**
    * Destroys the session
    *
    * @return void
@@ -58,4 +51,12 @@ interface ISession {
    * @throws web.session.SessionInvalid
    */
   public function remove($name);
+
+  /**
+   * Transmits this session to the response
+   *
+   * @param  web.Response $response
+   * @return void
+   */
+  public function transmit($response);
 }

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -63,8 +63,7 @@ class InFileSystem extends Sessions {
     $offset= 0;
 
     do {
-      $id= substr($buffer, $offset, 32);
-      $f= new File($this->path, $this->prefix.$id);
+      $f= new File($this->path, $this->prefix.substr($buffer, $offset, 32));
       if (!$f->exists()) {
         $this->gc();
         return new Session($this, $f, true, time() + $this->duration);

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -65,7 +65,7 @@ class InFileSystem extends Sessions {
     do {
       $id= substr($buffer, $offset, 32);
       $f= new File($this->path, $this->prefix.$id);
-      if (!$f->exists() && $f->touch()) {
+      if (!$f->exists()) {
         $this->gc();
         return new Session($this, $f, true, time() + $this->duration);
       }

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -56,10 +56,9 @@ class InFileSystem extends Sessions {
   /**
    * Creates a session
    *
-   * @param  web.Response $response
    * @return web.session.Session
    */
-  public function create($response) {
+  public function create() {
     $buffer= bin2hex($this->random->bytes(32));   // 64 bytes
     $offset= 0;
 
@@ -68,8 +67,7 @@ class InFileSystem extends Sessions {
       $f= new File($this->path, $this->prefix.$id);
       if (!$f->exists() && $f->touch()) {
         $this->gc();
-        $this->transmit($response, $id);
-        return new Session($f, time() + $this->duration);
+        return new Session($this, $f, true, time() + $this->duration);
       }
     } while ($offset++ < 32);
 
@@ -88,7 +86,7 @@ class InFileSystem extends Sessions {
       if ($f->exists()) {
         $created= $f->createdAt();
         if (time() - $created < $this->duration) {
-          return new Session($f, $created + $this->duration);
+          return new Session($this, $f, false, $created + $this->duration);
         }
         $f->unlink();
       }

--- a/src/main/php/web/session/InFileSystem.class.php
+++ b/src/main/php/web/session/InFileSystem.class.php
@@ -56,16 +56,19 @@ class InFileSystem extends Sessions {
   /**
    * Creates a session
    *
+   * @param  web.Response $response
    * @return web.session.Session
    */
-  public function create() {
+  public function create($response) {
     $buffer= bin2hex($this->random->bytes(32));   // 64 bytes
     $offset= 0;
 
     do {
-      $f= new File($this->path, $this->prefix.substr($buffer, $offset, 32));
+      $id= substr($buffer, $offset, 32);
+      $f= new File($this->path, $this->prefix.$id);
       if (!$f->exists() && $f->touch()) {
         $this->gc();
+        $this->transmit($response, $id);
         return new Session($f, time() + $this->duration);
       }
     } while ($offset++ < 32);
@@ -76,17 +79,19 @@ class InFileSystem extends Sessions {
   /**
    * Locates an existing session; returns NULL if there is no such session.
    *
-   * @param  string $id
+   * @param  web.Request $request
    * @return web.session.Session
    */
-  public function locate($id) {
-    $f= new File($this->path->getURI(), $this->prefix.$id);
-    if ($f->exists()) {
-      $created= $f->createdAt();
-      if (time() - $created < $this->duration) {
-        return new Session($f, $created + $this->duration);
+  public function locate($request) {
+    if ($id= $this->id($request)) {
+      $f= new File($this->path->getURI(), $this->prefix.$id);
+      if ($f->exists()) {
+        $created= $f->createdAt();
+        if (time() - $created < $this->duration) {
+          return new Session($f, $created + $this->duration);
+        }
+        $f->unlink();
       }
-      $f->unlink();
     }
     return null;
   }

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -1,6 +1,7 @@
 <?php namespace web\session;
 
 use util\TimeSpan;
+use web\Cookie;
 
 /**
  * Base class for session factories
@@ -22,6 +23,27 @@ abstract class Sessions {
   }
 
   /**
+   * Returns session ID from request 
+   *
+   * @param  web.Request $request
+   * @return string
+   */
+  public function id($request) {
+    return $request->cookie('session');
+  }
+
+  /**
+   * Sends session ID
+   *
+   * @param  web.Reponse
+   * @param  string $id
+   * @return void
+   */
+  public function transmit($response, $id) {
+    $response->cookie((new Cookie('session', $id))->maxAge($this->duration));
+  }
+
+  /**
    * Returns session duration in seconds
    *
    * @return int
@@ -31,28 +53,29 @@ abstract class Sessions {
   /**
    * Creates a session
    *
+   * @param  web.Response $response
    * @return web.session.Session
    */
-  public abstract function create();
+  public abstract function create($response);
 
   /**
    * Locates an existing and valid session; returns NULL if there is no such session.
    *
-   * @param  string $id
+   * @param  web.Request $request
    * @return web.session.ISession
    */
-  public abstract function locate($id);
+  public abstract function locate($request);
 
   /**
    * Opens an existing and valid session. Like `locate()` but raises an exception of
    * there is no such sessions.
    *
-   * @param  string $id The session ID
+   * @param  web.Request $request
    * @return web.session.ISession
    * @throws web.session.NoSuchSession
    */
-  public function open($id) {
-    if ($session= $this->locate($id)) return $session;
-    throw new NoSuchSession($id);
+  public function open($request) {
+    if ($session= $this->locate($request)) return $session;
+    throw new NoSuchSession($this->id($request));
   }
 }

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -42,6 +42,13 @@ abstract class Sessions {
   public function duration() { return $this->duration; }
 
   /**
+   * Returns session cookie name
+   *
+   * @return string
+   */
+  public function name() { return $this->cookie; }
+
+  /**
    * Returns session ID from request 
    *
    * @param  web.Request $request

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -24,6 +24,17 @@ abstract class Sessions {
   }
 
   /**
+   * Sets the cookie name
+   *
+   * @param  string $cookie
+   * @return self
+   */
+  public function named($cookie) {
+    $this->cookie= $cookie;
+    return $this;
+  }
+
+  /**
    * Returns session duration in seconds
    *
    * @return int

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -10,6 +10,7 @@ use web\Cookie;
  */
 abstract class Sessions {
   protected $duration= 86400;
+  protected $cookie= 'session';
 
   /**
    * Sets how long a session should last. Defaults to one day.
@@ -23,27 +24,6 @@ abstract class Sessions {
   }
 
   /**
-   * Returns session ID from request 
-   *
-   * @param  web.Request $request
-   * @return string
-   */
-  public function id($request) {
-    return $request->cookie('session');
-  }
-
-  /**
-   * Sends session ID
-   *
-   * @param  web.Reponse
-   * @param  string $id
-   * @return void
-   */
-  public function transmit($response, $id) {
-    $response->cookie((new Cookie('session', $id))->maxAge($this->duration));
-  }
-
-  /**
    * Returns session duration in seconds
    *
    * @return int
@@ -51,12 +31,41 @@ abstract class Sessions {
   public function duration() { return $this->duration; }
 
   /**
+   * Returns session ID from request 
+   *
+   * @param  web.Request $request
+   * @return string
+   */
+  public function id($request) { return $request->cookie($this->cookie); }
+
+  /**
+   * Attaches session ID to response 
+   *
+   * @param  string $id
+   * @param  web.Response $response
+   * @return vod
+   */
+  public function attach($id, $response) {
+    $response->cookie((new Cookie($this->cookie, $id))->maxAge($this->duration));
+  }
+
+  /**
+   * Detaches session ID from response 
+   *
+   * @param  string $id
+   * @param  web.Response $response
+   * @return vod
+   */
+  public function detach($id, $response) {
+    $response->cookie(new Cookie($this->cookie, null));
+  }
+
+  /**
    * Creates a session
    *
-   * @param  web.Response $response
    * @return web.session.Session
    */
-  public abstract function create($response);
+  public abstract function create();
 
   /**
    * Locates an existing and valid session; returns NULL if there is no such session.

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -81,7 +81,7 @@ class Session implements ISession {
   /** @return void */
   public function destroy() {
     $this->eol= time() - 1;
-    $this->modifications= [];
+    $this->new= false;
     $this->file->unlink();
   }
 

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -10,7 +10,7 @@ use io\File;
  * @see   xp://web.session.InFileSystem
  */
 class Session implements ISession {
-  private $new, $file, $eol;
+  private $sessions, $new, $file, $eol;
   private $values= null;
   private $modifications= [];
 

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -1,6 +1,7 @@
 <?php namespace web\session\filesystem;
 
 use web\session\ISession;
+use web\session\SessionInvalid;
 use io\File;
 
 /**
@@ -9,19 +10,26 @@ use io\File;
  * @see   xp://web.session.InFileSystem
  */
 class Session implements ISession {
-  private $file, $eol;
+  private $new, $file, $eol;
   private $values= null;
   private $modifications= [];
 
   /**
    * Creates a new file-based session
    *
+   * @param  web.session.Sessions $sessions
    * @param  string|io.File $file
+   * @param  bool $new
    * @param  int eol
    */
-  public function __construct($file, $eol) {
+  public function __construct($sessions, $file, $new, $eol) {
+    $this->sessions= $sessions;
     $this->file= $file instanceof File ? $file : new File($file);
+    $this->new= $new;
     $this->eol= $eol;
+
+    // Prevent open() from accessing filesystem
+    $new && $this->values= [];
   }
 
   /** @return string */
@@ -73,32 +81,6 @@ class Session implements ISession {
   }
 
   /** @return void */
-  public function close() {
-    if (empty($this->modifications)) return;
-
-    $this->file->open(File::READWRITE);
-    $this->file->lockExclusive();
-
-    // Read file to ensure we have the most current version of the data
-    if (0 === $size= $this->size()) {
-      $this->values= [];
-    } else {
-      $this->values= unserialize($this->file->read($size));
-      $this->file->seek(0, SEEK_SET);
-    }
-
-    // Replay all modifications, then write back
-    foreach ($this->modifications as $name => $modification) {
-      $modification($name);
-    }
-    $this->modifications= [];
-    $this->file->write(serialize($this->values));
-
-    $this->file->unLock();
-    $this->file->close();
-  }
-
-  /** @return void */
   public function destroy() {
     $this->eol= time() - 1;
     $this->modifications= [];
@@ -141,5 +123,44 @@ class Session implements ISession {
   public function remove($name) {
     $this->open();
     $this->modify($name, function() use($name) { unset($this->values[$name]); });
+  }
+
+  /**
+   * Transmits this session to the response
+   *
+   * @param  web.Response $response
+   * @return void
+   */
+  public function transmit($response) {
+    if ($this->new) {
+      $this->sessions->attach($this->id(), $response);
+      $this->new= false;
+    } else if (time() >= $this->eol) {
+      $this->sessions->detach($this->id(), $response);
+      return;
+    } else if (empty($this->modifications)) {
+      return;
+    }
+
+    $this->file->open(File::READWRITE);
+    $this->file->lockExclusive();
+
+    // Read file to ensure we have the most current version of the data
+    if (0 === $size= $this->size()) {
+      $this->values= [];
+    } else {
+      $this->values= unserialize($this->file->read($size));
+      $this->file->seek(0, SEEK_SET);
+    }
+
+    // Replay all modifications, then write back
+    foreach ($this->modifications as $name => $modification) {
+      $modification($name);
+    }
+    $this->modifications= [];
+    $this->file->write(serialize($this->values));
+
+    $this->file->unLock();
+    $this->file->close();
   }
 }

--- a/src/main/php/web/session/testing/Session.class.php
+++ b/src/main/php/web/session/testing/Session.class.php
@@ -9,7 +9,7 @@ use web\session\SessionInvalid;
  * @see   xp://web.session.ForTesting
  */
 class Session implements ISession {
-  private $new, $id, $eol;
+  private $sessions, $new, $id, $eol;
   private $values= [];
 
   /**

--- a/src/test/php/web/session/unittest/ForTestingTest.class.php
+++ b/src/test/php/web/session/unittest/ForTestingTest.class.php
@@ -8,4 +8,16 @@ class ForTestingTest extends SessionsTest {
   /** @return web.session.Sessions */
   protected function fixture() { return new ForTesting(); }
 
+  #[@test]
+  public function all_initially_empty() {
+    $sessions= $this->fixture();
+    $this->assertEquals([], $sessions->all());
+  }
+
+  #[@test]
+  public function all_after_creating_session() {
+    $sessions= $this->fixture();
+    $created= $sessions->create();
+    $this->assertEquals([$created->id() => $created], $sessions->all());
+  }
 }

--- a/src/test/php/web/session/unittest/ForTestingTest.class.php
+++ b/src/test/php/web/session/unittest/ForTestingTest.class.php
@@ -1,10 +1,9 @@
 <?php namespace web\session\unittest;
 
-use unittest\TestCase;
 use web\session\ForTesting;
 use web\session\ISession;
 
-class ForTestingTest extends TestCase {
+class ForTestingTest extends SessionsTest {
 
   #[@test]
   public function can_create() {
@@ -14,38 +13,38 @@ class ForTestingTest extends TestCase {
   #[@test]
   public function create_session() {
     $factory= new ForTesting();
-    $this->assertInstanceOf(ISession::class, $factory->create());
+    $this->assertInstanceOf(ISession::class, $factory->create($this->response()));
   }
 
   #[@test]
   public function valid() {
-    $session= (new ForTesting())->create();
+    $session= (new ForTesting())->create($this->response());
     $this->assertTrue($session->valid());
   }
 
   #[@test]
   public function no_longer_valid_after_having_been_destroyed() {
-    $session= (new ForTesting())->create();
+    $session= (new ForTesting())->create($this->response());
     $session->destroy();
     $this->assertFalse($session->valid());
   }
 
   #[@test]
   public function read_and_write() {
-    $session= (new ForTesting())->create();
+    $session= (new ForTesting())->create($this->response());
     $session->register('test', 'Test the west');
     $this->assertEquals('Test the west', $session->value('test'));
   }
 
   #[@test]
   public function read_non_existant_returns_default() {
-    $session= (new ForTesting())->create();
+    $session= (new ForTesting())->create($this->response());
     $this->assertEquals('Default value', $session->value('test', 'Default value'));
   }
 
   #[@test]
   public function remove() {
-    $session= (new ForTesting())->create();
+    $session= (new ForTesting())->create($this->response());
     $session->register('test', 'Test the west');
     $session->remove('test');
     $this->assertNull($session->value('test'));

--- a/src/test/php/web/session/unittest/ForTestingTest.class.php
+++ b/src/test/php/web/session/unittest/ForTestingTest.class.php
@@ -5,48 +5,7 @@ use web\session\ISession;
 
 class ForTestingTest extends SessionsTest {
 
-  #[@test]
-  public function can_create() {
-    new ForTesting();
-  }
+  /** @return web.session.Sessions */
+  protected function fixture() { return new ForTesting(); }
 
-  #[@test]
-  public function create_session() {
-    $factory= new ForTesting();
-    $this->assertInstanceOf(ISession::class, $factory->create());
-  }
-
-  #[@test]
-  public function valid() {
-    $session= (new ForTesting())->create();
-    $this->assertTrue($session->valid());
-  }
-
-  #[@test]
-  public function no_longer_valid_after_having_been_destroyed() {
-    $session= (new ForTesting())->create();
-    $session->destroy();
-    $this->assertFalse($session->valid());
-  }
-
-  #[@test]
-  public function read_and_write() {
-    $session= (new ForTesting())->create();
-    $session->register('test', 'Test the west');
-    $this->assertEquals('Test the west', $session->value('test'));
-  }
-
-  #[@test]
-  public function read_non_existant_returns_default() {
-    $session= (new ForTesting())->create();
-    $this->assertEquals('Default value', $session->value('test', 'Default value'));
-  }
-
-  #[@test]
-  public function remove() {
-    $session= (new ForTesting())->create();
-    $session->register('test', 'Test the west');
-    $session->remove('test');
-    $this->assertNull($session->value('test'));
-  }
 }

--- a/src/test/php/web/session/unittest/ForTestingTest.class.php
+++ b/src/test/php/web/session/unittest/ForTestingTest.class.php
@@ -10,8 +10,7 @@ class ForTestingTest extends SessionsTest {
 
   #[@test]
   public function all_initially_empty() {
-    $sessions= $this->fixture();
-    $this->assertEquals([], $sessions->all());
+    $this->assertEquals([], $this->fixture()->all());
   }
 
   #[@test]

--- a/src/test/php/web/session/unittest/ForTestingTest.class.php
+++ b/src/test/php/web/session/unittest/ForTestingTest.class.php
@@ -13,38 +13,38 @@ class ForTestingTest extends SessionsTest {
   #[@test]
   public function create_session() {
     $factory= new ForTesting();
-    $this->assertInstanceOf(ISession::class, $factory->create($this->response()));
+    $this->assertInstanceOf(ISession::class, $factory->create());
   }
 
   #[@test]
   public function valid() {
-    $session= (new ForTesting())->create($this->response());
+    $session= (new ForTesting())->create();
     $this->assertTrue($session->valid());
   }
 
   #[@test]
   public function no_longer_valid_after_having_been_destroyed() {
-    $session= (new ForTesting())->create($this->response());
+    $session= (new ForTesting())->create();
     $session->destroy();
     $this->assertFalse($session->valid());
   }
 
   #[@test]
   public function read_and_write() {
-    $session= (new ForTesting())->create($this->response());
+    $session= (new ForTesting())->create();
     $session->register('test', 'Test the west');
     $this->assertEquals('Test the west', $session->value('test'));
   }
 
   #[@test]
   public function read_non_existant_returns_default() {
-    $session= (new ForTesting())->create($this->response());
+    $session= (new ForTesting())->create();
     $this->assertEquals('Default value', $session->value('test', 'Default value'));
   }
 
   #[@test]
   public function remove() {
-    $session= (new ForTesting())->create($this->response());
+    $session= (new ForTesting())->create();
     $session->register('test', 'Test the west');
     $session->remove('test');
     $this->assertNull($session->value('test'));

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -4,7 +4,6 @@ use io\Folder;
 use lang\Environment;
 use lang\IllegalArgumentException;
 use web\session\InFileSystem;
-use web\session\ISession;
 
 class InFileSystemTest extends SessionsTest {
   private static $dir;
@@ -20,14 +19,12 @@ class InFileSystemTest extends SessionsTest {
     self::$dir->exists() && self::$dir->unlink();
   }
 
-  #[@test]
-  public function can_create() {
-    new InFileSystem();
-  }
+  /** @return web.session.Sessions */
+  protected function fixture() { return new InFileSystem(self::$dir); }
 
   #[@test]
-  public function can_create_with_dir() {
-    new InFileSystem(self::$dir);
+  public function can_create_without_argument() {
+    new InFileSystem();
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
@@ -36,64 +33,9 @@ class InFileSystemTest extends SessionsTest {
   }
 
   #[@test]
-  public function create() {
-    $sessions= new InFileSystem(self::$dir);
-    $this->assertInstanceOf(ISession::class, $sessions->create());
-  }
-
-  #[@test]
   public function session_identifiers_consist_of_32_lowercase_hex_digits() {
-    $sessions= new InFileSystem(self::$dir);
+    $sessions= $this->fixture();
     $id= $sessions->create()->id();
     $this->assertTrue((bool)preg_match('/^[a-f0-9]{32}$/i', $id), $id);
-  }
-
-  #[@test]
-  public function read_write() {
-    $session= (new InFileSystem(self::$dir))->create();
-    $session->register('name', 'value');
-    $this->assertEquals('value', $session->value('name'));
-  }
-
-  #[@test]
-  public function read_non_existant() {
-    $session= (new InFileSystem(self::$dir))->create();
-    $this->assertNull($session->value('name'));
-  }
-
-  #[@test]
-  public function read_non_existant_returns_default() {
-    $session= (new InFileSystem(self::$dir))->create();
-    $this->assertEquals('Default value', $session->value('name', 'Default value'));
-  }
-
-  #[@test]
-  public function remove() {
-    $session= (new InFileSystem(self::$dir))->create();
-    $session->register('name', 'value');
-    $session->remove('name');
-    $this->assertNull($session->value('name'));
-  }
-
-  #[@test]
-  public function read_write_with_two_session_instances() {
-    $sessions= new InFileSystem(self::$dir);
-
-    $session= $sessions->create();
-    $session->register('name', 'value');
-    $session->transmit($this->response());
-
-    $session= $sessions->open($this->request('session='.$session->id()));
-    $value= $session->value('name');
-
-    $this->assertEquals('value', $value);
-  }
-
-  #[@test]
-  public function destroy() {
-    $session= (new InFileSystem(self::$dir))->create();
-    $session->register('name', 'value');
-    $session->destroy();
-    $this->assertFalse($session->valid());
   }
 }

--- a/src/test/php/web/session/unittest/InFileSystemTest.class.php
+++ b/src/test/php/web/session/unittest/InFileSystemTest.class.php
@@ -38,83 +38,62 @@ class InFileSystemTest extends SessionsTest {
   #[@test]
   public function create() {
     $sessions= new InFileSystem(self::$dir);
-    $this->assertInstanceOf(ISession::class, $sessions->create($this->response()));
+    $this->assertInstanceOf(ISession::class, $sessions->create());
   }
 
   #[@test]
   public function session_identifiers_consist_of_32_lowercase_hex_digits() {
     $sessions= new InFileSystem(self::$dir);
-    $id= $sessions->create($this->response())->id();
+    $id= $sessions->create()->id();
     $this->assertTrue((bool)preg_match('/^[a-f0-9]{32}$/i', $id), $id);
   }
 
   #[@test]
   public function read_write() {
-    $session= (new InFileSystem(self::$dir))->create($this->response());
-    try {
-      $session->register('name', 'value');
-      $this->assertEquals('value', $session->value('name'));
-    } finally {
-      $session->close();
-    }
+    $session= (new InFileSystem(self::$dir))->create();
+    $session->register('name', 'value');
+    $this->assertEquals('value', $session->value('name'));
   }
 
   #[@test]
   public function read_non_existant() {
-    $session= (new InFileSystem(self::$dir))->create($this->response());
-    try {
-      $this->assertNull($session->value('name'));
-    } finally {
-      $session->close();
-    }
+    $session= (new InFileSystem(self::$dir))->create();
+    $this->assertNull($session->value('name'));
   }
 
   #[@test]
   public function read_non_existant_returns_default() {
-    $session= (new InFileSystem(self::$dir))->create($this->response());
-    try {
-      $this->assertEquals('Default value', $session->value('name', 'Default value'));
-    } finally {
-      $session->close();
-    }
+    $session= (new InFileSystem(self::$dir))->create();
+    $this->assertEquals('Default value', $session->value('name', 'Default value'));
   }
 
   #[@test]
   public function remove() {
-    $session= (new InFileSystem(self::$dir))->create($this->response());
-    try {
-      $session->register('name', 'value');
-      $session->remove('name');
-      $this->assertNull($session->value('name'));
-    } finally {
-      $session->close();
-    }
+    $session= (new InFileSystem(self::$dir))->create();
+    $session->register('name', 'value');
+    $session->remove('name');
+    $this->assertNull($session->value('name'));
   }
 
   #[@test]
   public function read_write_with_two_session_instances() {
     $sessions= new InFileSystem(self::$dir);
 
-    $session= $sessions->create($this->response());
+    $session= $sessions->create();
     $session->register('name', 'value');
-    $session->close();
+    $session->transmit($this->response());
 
     $session= $sessions->open($this->request('session='.$session->id()));
     $value= $session->value('name');
-    $session->close();
 
     $this->assertEquals('value', $value);
   }
 
   #[@test]
   public function destroy() {
-    $session= (new InFileSystem(self::$dir))->create($this->response());
-    try {
-      $session->register('name', 'value');
-      $session->destroy();
-      $this->assertFalse($session->valid());
-    } finally {
-      $session->close();
-    }
+    $session= (new InFileSystem(self::$dir))->create();
+    $session->register('name', 'value');
+    $session->destroy();
+    $this->assertFalse($session->valid());
   }
 }

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -45,13 +45,14 @@ abstract class SessionsTest extends TestCase {
     $session= $sessions->create();
     $session->transmit($this->response());
 
-    $session= $sessions->open($this->request('session='.$session->id()));
+    $session= $sessions->open($this->request($sessions->name().'='.$session->id()));
     $this->assertInstanceOf(ISession::class, $session);
   }
 
   #[@test, @expect(NoSuchSession::class)]
   public function open_non_existant() {
-    $this->fixture()->open($this->request('session=@non-existant@'));
+    $sessions= $this->fixture();
+    $sessions->open($this->request($sessions->name().'=@non-existant@'));
   }
 
   #[@test]
@@ -60,13 +61,14 @@ abstract class SessionsTest extends TestCase {
     $session= $sessions->create();
     $session->transmit($this->response());
 
-    $session= $sessions->locate($this->request('session='.$session->id()));
+    $session= $sessions->locate($this->request($sessions->name().'='.$session->id()));
     $this->assertInstanceOf(ISession::class, $session);
   }
 
   #[@test]
   public function locate_non_existant() {
-    $this->assertNull($this->fixture()->locate($this->request('session=@non-existant@')));
+    $sessions= $this->fixture();
+    $this->assertNull($sessions->locate($this->request($sessions->name().'=@non-existant@')));
   }
 
   #[@test]
@@ -103,6 +105,13 @@ abstract class SessionsTest extends TestCase {
   }
 
   #[@test]
+  public function remove_non_existant() {
+    $session= $this->fixture()->create();
+    $session->remove('name');
+    $this->assertNull($session->value('name'));
+  }
+
+  #[@test]
   public function read_write_with_two_session_instances() {
     $sessions= $this->fixture();
 
@@ -110,7 +119,7 @@ abstract class SessionsTest extends TestCase {
     $session->register('name', 'value');
     $session->transmit($this->response());
 
-    $session= $sessions->open($this->request('session='.$session->id()));
+    $session= $sessions->open($this->request($sessions->name().'='.$session->id()));
     $value= $session->value('name');
 
     $this->assertEquals('value', $value);

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -1,11 +1,12 @@
 <?php namespace web\session\unittest;
 
 use unittest\TestCase;
-use web\Request;
-use web\Response;
 use web\io\TestInput;
 use web\io\TestOutput;
+use web\Request;
+use web\Response;
 use web\session\ISession;
+use web\session\NoSuchSession;
 use web\session\SessionInvalid;
 
 abstract class SessionsTest extends TestCase {
@@ -36,6 +37,36 @@ abstract class SessionsTest extends TestCase {
   public function create() {
     $sessions= $this->fixture();
     $this->assertInstanceOf(ISession::class, $sessions->create());
+  }
+
+  #[@test]
+  public function open() {
+    $sessions= $this->fixture();
+    $session= $sessions->create();
+    $session->transmit($this->response());
+
+    $session= $sessions->open($this->request('session='.$session->id()));
+    $this->assertInstanceOf(ISession::class, $session);
+  }
+
+  #[@test, @expect(NoSuchSession::class)]
+  public function open_non_existant() {
+    $this->fixture()->open($this->request('session=@non-existant@'));
+  }
+
+  #[@test]
+  public function locate() {
+    $sessions= $this->fixture();
+    $session= $sessions->create();
+    $session->transmit($this->response());
+
+    $session= $sessions->locate($this->request('session='.$session->id()));
+    $this->assertInstanceOf(ISession::class, $session);
+  }
+
+  #[@test]
+  public function locate_non_existant() {
+    $this->assertNull($this->fixture()->locate($this->request('session=@non-existant@')));
   }
 
   #[@test]

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -5,6 +5,8 @@ use web\Request;
 use web\Response;
 use web\io\TestInput;
 use web\io\TestOutput;
+use web\session\ISession;
+use web\session\SessionInvalid;
 
 abstract class SessionsTest extends TestCase {
 
@@ -25,5 +27,89 @@ abstract class SessionsTest extends TestCase {
    */
   protected function response() {
     return new Response(new TestOutput());
+  }
+
+  /** @return web.session.Sessions */
+  protected abstract function fixture();
+
+  #[@test]
+  public function create() {
+    $sessions= $this->fixture();
+    $this->assertInstanceOf(ISession::class, $sessions->create());
+  }
+
+  #[@test]
+  public function valid() {
+    $session= $this->fixture()->create();
+    $this->assertTrue($session->valid());
+  }
+
+  #[@test]
+  public function read_write() {
+    $session= $this->fixture()->create();
+    $session->register('name', 'value');
+    $this->assertEquals('value', $session->value('name'));
+  }
+
+  #[@test]
+  public function read_non_existant() {
+    $session= $this->fixture()->create();
+    $this->assertNull($session->value('name'));
+  }
+
+  #[@test]
+  public function read_non_existant_returns_default() {
+    $session= $this->fixture()->create();
+    $this->assertEquals('Default value', $session->value('name', 'Default value'));
+  }
+
+  #[@test]
+  public function remove() {
+    $session= $this->fixture()->create();
+    $session->register('name', 'value');
+    $session->remove('name');
+    $this->assertNull($session->value('name'));
+  }
+
+  #[@test]
+  public function read_write_with_two_session_instances() {
+    $sessions= $this->fixture();
+
+    $session= $sessions->create();
+    $session->register('name', 'value');
+    $session->transmit($this->response());
+
+    $session= $sessions->open($this->request('session='.$session->id()));
+    $value= $session->value('name');
+
+    $this->assertEquals('value', $value);
+  }
+
+  #[@test]
+  public function no_longer_valid_after_having_been_destroyed() {
+    $session= $this->fixture()->create();
+    $session->destroy();
+    $this->assertFalse($session->valid());
+  }
+
+  #[@test, @expect(SessionInvalid::class)]
+  public function cannot_read_after_destroying() {
+    $session= $this->fixture()->create();
+    $session->destroy();
+    $session->value('any');
+  }
+
+  #[@test, @expect(SessionInvalid::class)]
+  public function cannot_write_after_destroying() {
+    $session= $this->fixture()->create();
+    $session->destroy();
+    $session->register('any', 'value');
+  }
+
+  #[@test, @expect(SessionInvalid::class)]
+  public function cannot_remove_after_destroying() {
+    $session= $this->fixture()->create();
+    $session->destroy();
+    $session->remove('any');
   }
 }

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -70,6 +70,17 @@ abstract class SessionsTest extends TestCase {
   }
 
   #[@test]
+  public function locate_invalid() {
+    $sessions= $this->fixture();
+
+    $session= $sessions->create();
+    $session->destroy();
+    $session->transmit($this->response());
+
+    $this->assertNull($sessions->locate($this->request($sessions->name().'='.$session->id())));
+  }
+
+  #[@test]
   public function locate_non_existant() {
     $sessions= $this->fixture();
     $this->assertNull($sessions->locate($this->request($sessions->name().'=@non-existant@')));

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -42,11 +42,13 @@ abstract class SessionsTest extends TestCase {
   #[@test]
   public function open() {
     $sessions= $this->fixture();
+
     $session= $sessions->create();
+    $session->register('id', 'Test');
     $session->transmit($this->response());
 
     $session= $sessions->open($this->request($sessions->name().'='.$session->id()));
-    $this->assertInstanceOf(ISession::class, $session);
+    $this->assertEquals('Test', $session->value('id'));
   }
 
   #[@test, @expect(NoSuchSession::class)]
@@ -58,11 +60,13 @@ abstract class SessionsTest extends TestCase {
   #[@test]
   public function locate() {
     $sessions= $this->fixture();
+
     $session= $sessions->create();
+    $session->register('id', 'Test');
     $session->transmit($this->response());
 
     $session= $sessions->locate($this->request($sessions->name().'='.$session->id()));
-    $this->assertInstanceOf(ISession::class, $session);
+    $this->assertEquals('Test', $session->value('id'));
   }
 
   #[@test]

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -1,0 +1,29 @@
+<?php namespace web\session\unittest;
+
+use unittest\TestCase;
+use web\Request;
+use web\Response;
+use web\io\TestInput;
+use web\io\TestOutput;
+
+abstract class SessionsTest extends TestCase {
+
+  /**
+   * Creates a request
+   *
+   * @param  string $cookie
+   * @return web.Request
+   */
+  protected function request($cookie= null) {
+    return new Request(new TestInput('GET', '/', $cookie ? ['Cookie' => $cookie] : []));
+  }
+
+  /**
+   * Creates a response
+   *
+   * @return web.Response
+   */
+  protected function response() {
+    return new Response(new TestOutput());
+  }
+}


### PR DESCRIPTION
This pull request changes the `open()` and `locate()` methods to check the request, and changes `close()` to `transmit()`, which is passed a response.

## Motivation

* Built-in cookie handling
* Less code to get wrong 😄 
* Possibility to add cookie-only sessions, e.g. via JWTs

## Refactoring example

```diff
--- a/src/main/php/web/auth/cas/CasLogin.class.php
+++ b/src/main/php/web/auth/cas/CasLogin.class.php
@@ -84,12 +84,8 @@ class CasLogin implements Filter {
       }

       $session= $this->sessions->create();
-      try {
-        $session->register('user', $user);
-        $response->cookie((new Cookie('session', $session->id()))->maxAge($this->sessions->duration()));
-      } finally {
-        $session->close();
-      }
+      $session->register('user', $user);
+      $session->transmit($response);

       $response->answer(302);
       $response->header('Location', $service);
@@ -97,14 +93,14 @@ class CasLogin implements Filter {
     }

     // Handle session
-    if ($session= $this->sessions->locate($request->cookie('session'))) {
+    if ($session= $this->sessions->locate($request)) {
       try {
         $request->pass('user', $session->value('user'));
         return $invocation->proceed($request, $response);
       } catch (SessionInvalid $e) {
         // Fall through, relogin
       } finally {
-        $session->close();
+        $session->transmit($response);
       }
     }
```

## See also

http://www.gorillatoolkit.org/pkg/sessions
