### PR TITLE
Switch session cookie to only use secure transport by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,10 @@
 Sessions for the XP Framework ChangeLog
 ========================================================================
 
-## ?.?.? / ????-??-??
+## 0.6.0 / ????-??-??
+
+* Changed session cookie to be transmitted via HTTPS only by default.
+* Added web.session.Session::disableSecure() to restore old behaviour.
 
 ## 0.5.0 / 2018-08-22
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ Sessions for the XP Framework ChangeLog
 ## 0.6.0 / ????-??-??
 
 * Changed session cookie to be transmitted via HTTPS only by default.
-* Added web.session.Session::disableSecure() to restore old behaviour.
+* Added web.session.Session::insecure(bool $whether) to restore old behaviour.
 
 ## 0.5.0 / 2018-08-22
 

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -12,6 +12,7 @@ abstract class Sessions {
   protected $duration= 86400;
   protected $cookie= 'session';
   protected $path= '/';
+  protected $secure= true;
 
   /**
    * Sets how long a session should last. Defaults to one day.
@@ -47,6 +48,16 @@ abstract class Sessions {
   }
 
   /**
+   * Disables to only transmit session cookie via secure connections (HTTPS).
+   *
+   * @return self
+   */
+  public function disableSecure() {
+    $this->secure= false;
+    return $this;
+  }
+
+  /**
    * Returns session duration in seconds
    *
    * @return int
@@ -68,7 +79,14 @@ abstract class Sessions {
   public function path() { return $this->path; }
 
   /**
-   * Returns session ID from request 
+   * Returns whether session cookie is set with secure flag
+   *
+   * @return  bool
+   */
+  public function isSecure() { return $this->secure; }
+
+  /**
+   * Returns session ID from request
    *
    * @param  web.Request $request
    * @return string
@@ -93,7 +111,7 @@ abstract class Sessions {
    * @return void
    */
   public function attach($id, $response) {
-    $response->cookie((new Cookie($this->cookie, $id))->maxAge($this->duration)->path($this->path));
+    $response->cookie((new Cookie($this->cookie, $id))->maxAge($this->duration)->path($this->path)->secure($this->secure));
   }
 
   /**

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -48,12 +48,13 @@ abstract class Sessions {
   }
 
   /**
-   * Disables to only transmit session cookie via secure connections (HTTPS).
+   * Sets whether secure transport for cookies should be enabled or disabled.
    *
+   * @param  bool $whether
    * @return self
    */
-  public function disableSecure() {
-    $this->secure= false;
+  public function insecure(bool $whether) {
+    $this->secure= !$whether;
     return $this;
   }
 

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -51,6 +51,18 @@ abstract class SessionsTest extends TestCase {
   }
 
   #[@test]
+  public function secureByDefault() {
+    $sessions= $this->fixture();
+    $this->assertTrue($sessions->isSecure());
+  }
+
+  #[@test]
+  public function secureDisabled() {
+    $sessions= $this->fixture();
+    $this->assertFalse($sessions->disableSecure()->isSecure());
+  }
+
+  #[@test]
   public function open() {
     $sessions= $this->fixture();
 

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -57,9 +57,15 @@ abstract class SessionsTest extends TestCase {
   }
 
   #[@test]
-  public function secureDisabled() {
+  public function secureWhenInsecureSetToFalse() {
     $sessions= $this->fixture();
-    $this->assertFalse($sessions->disableSecure()->isSecure());
+    $this->assertTrue($sessions->insecure(false)->isSecure());
+  }
+
+  #[@test]
+  public function notSecureWhenInsecureSetToTrue() {
+    $sessions= $this->fixture();
+    $this->assertFalse($sessions->insecure(true)->isSecure());
   }
 
   #[@test]


### PR DESCRIPTION
This will set the session cookie to be used via secure transport (HTTPS) only. If the old behaviour of not requiring secure transport is needed in an application it can be enabled by calling `Sessions::disableSecure()`.