### PR TITLE
Add possibility to change sameSite attribute of session cookie

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 Sessions for the XP Framework ChangeLog
 ========================================================================
 
+## 0.7.0 / ????-??-??
+
+* Added possibility to change sameSite attribute of session cookie
+
 ## 0.6.0 / 2019-06-13
 
 * Merged PR #6: Secure session cookies

--- a/src/main/php/web/session/Sessions.class.php
+++ b/src/main/php/web/session/Sessions.class.php
@@ -13,6 +13,7 @@ abstract class Sessions {
   protected $cookie= 'session';
   protected $path= '/';
   protected $secure= true;
+  protected $sameSite= 'Lax';
 
   /**
    * Sets how long a session should last. Defaults to one day.
@@ -59,6 +60,17 @@ abstract class Sessions {
   }
 
   /**
+   * Switch whether to transmit session cookie only to same site; preventing CSRF
+   *
+   * @param  string $sameSite one of "Strict", "Lax" or null (use the latter to remove)
+   * @return self
+   */
+  public function sameSite($sameSite) {
+    $this->sameSite= $sameSite;
+    return $this;
+  }
+
+  /**
    * Returns session duration in seconds
    *
    * @return int
@@ -85,6 +97,16 @@ abstract class Sessions {
    * @return  bool
    */
   public function isSecure() { return $this->secure; }
+
+  /**
+   * Returns whether sameSite attribute is set to given value.
+   *
+   * @param  string $value
+   * @return bool
+   */
+  public function sameSiteIs($value) {
+    return $this->sameSite === $value;
+  }
 
   /**
    * Returns session ID from request

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -69,6 +69,19 @@ abstract class SessionsTest extends TestCase {
   }
 
   #[@test]
+  public function sameSiteIsLaxByDefault() {
+    $sessions= $this->fixture();
+    $this->assertTrue($sessions->sameSiteIs('Lax'));
+  }
+
+  #[@test]
+  public function sameSiteCanBeUnset() {
+    $sessions= $this->fixture();
+    $sessions->sameSite(null);
+    $this->assertTrue($sessions->sameSiteIs(null));
+  }
+
+  #[@test]
   public function open() {
     $sessions= $this->fixture();
 


### PR DESCRIPTION
This allows to enforce another sameSite policy for session cookies: either a more strict one, or to remove the policy at all to retain bc with other features not easily changeable.