### PR TITLE
Add `web.session.Persistence` base class superseding the `ISession` interface

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ Sessions for the XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* Added PHP 8.6 to the test matrix - @thekid
+
 ## 4.0.0 / ????-??-??
 
 * **Heads up:** Dropped support for PHP < 7.4, see xp-framework/rfc#343

--- a/src/main/php/web/session/ISession.class.php
+++ b/src/main/php/web/session/ISession.class.php
@@ -62,13 +62,6 @@ interface ISession extends Closeable {
   public function remove($name);
 
   /**
-   * Closes this session
-   *
-   * @return void
-   */
-  public function close();
-
-  /**
    * Closes and transmits this session to the response
    *
    * @param  web.Response $response

--- a/src/main/php/web/session/Persistence.class.php
+++ b/src/main/php/web/session/Persistence.class.php
@@ -41,4 +41,12 @@ abstract class Persistence implements ISession {
 
     $this->close();
   }
+
+  /**
+   * Closes this session. Does nothing in this default implementation,
+   * override in subclasses.
+   *
+   * @return void
+   */
+  public function close() { }
 }

--- a/src/main/php/web/session/Persistence.class.php
+++ b/src/main/php/web/session/Persistence.class.php
@@ -1,0 +1,44 @@
+<?php namespace web\session;
+
+/** Base class for session stores */
+abstract class Persistence implements ISession {
+  protected $sessions, $detached, $expires;
+
+  /**
+   * Creates a new in-memory session
+   *
+   * @param  web.session.Sessions $sessions
+   * @param  bool $detached
+   * @param  int $expires
+   */
+  public function __construct($sessions, $detached, $expires) {
+    $this->sessions= $sessions;
+    $this->detached= $detached;
+    $this->expires= $expires;
+  }
+
+  /** @return bool */
+  public function valid() { return time() < $this->expires; }
+
+  /** @return int */
+  public function expires() { return $this->expires; }
+
+  /**
+   * Transmits this session to the response
+   *
+   * @param  web.Response $response
+   * @return void
+   */
+  public function transmit($response) {
+    if ($this->detached) {
+      $this->sessions->attach($this, $response);
+      $this->detached= false;
+      // Fall through, writing session data
+    } else if (time() >= $this->expires) {
+      $this->sessions->detach($this, $response);
+      return;
+    }
+
+    $this->close();
+  }
+}

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -40,7 +40,7 @@ class Session implements ISession {
   public function valid() { return time() < $this->eol; }
 
   /** @return int */
-  public function remaining($time= null) { return $this->eol - ($time ?? time()); }
+  public function expires() { return $this->eol; }
 
   /** @return int */
   private function size() {

--- a/src/main/php/web/session/filesystem/Session.class.php
+++ b/src/main/php/web/session/filesystem/Session.class.php
@@ -6,7 +6,7 @@ use web\session\{ISession, SessionInvalid};
 /**
  * A session stored in the filesystem
  *
- * @see   xp://web.session.InFileSystem
+ * @see   web.session.InFileSystem
  */
 class Session implements ISession {
   private $sessions, $new, $file, $eol;
@@ -19,7 +19,7 @@ class Session implements ISession {
    * @param  web.session.Sessions $sessions
    * @param  string|io.File $file
    * @param  bool $new
-   * @param  int eol
+   * @param  int $eol
    */
   public function __construct($sessions, $file, $new, $eol) {
     $this->sessions= $sessions;
@@ -38,6 +38,9 @@ class Session implements ISession {
 
   /** @return bool */
   public function valid() { return time() < $this->eol; }
+
+  /** @return int */
+  public function remaining($time= null) { return $this->eol - ($time ?? time()); }
 
   /** @return int */
   private function size() {

--- a/src/main/php/web/session/testing/Session.class.php
+++ b/src/main/php/web/session/testing/Session.class.php
@@ -92,13 +92,4 @@ class Session extends Persistence {
       return false;
     }
   }
-
-  /**
-   * Closes this session
-   *
-   * @return void
-   */
-  public function close() {
-    // NOOP
-  }
 }

--- a/src/main/php/web/session/testing/Session.class.php
+++ b/src/main/php/web/session/testing/Session.class.php
@@ -1,14 +1,14 @@
 <?php namespace web\session\testing;
 
-use web\session\{ISession, SessionInvalid};
+use web\session\{Persistence, SessionInvalid};
 
 /**
  * A testing session
  *
  * @see   web.session.ForTesting
  */
-class Session implements ISession {
-  private $sessions, $new, $id, $eol;
+class Session extends Persistence {
+  private $id;
   private $values= [];
 
   /**
@@ -16,24 +16,16 @@ class Session implements ISession {
    *
    * @param  web.session.Sessions $sessions
    * @param  string $id
-   * @param  bool $new
-   * @param  int $eol
+   * @param  bool $detached
+   * @param  int $expires
    */
-  public function __construct($sessions, $id, $new, $eol) {
-    $this->sessions= $sessions;
+  public function __construct($sessions, $id, $detached, $expires) {
+    parent::__construct($sessions, $detached, $expires);
     $this->id= $id;
-    $this->new= $new;
-    $this->eol= $eol;
   }
 
   /** @return string */
   public function id() { return $this->id; }
-
-  /** @return bool */
-  public function valid() { return time() < $this->eol; }
-
-  /** @return int */
-  public function expires() { return $this->eol; }
 
   /**
    * Returns all session keys
@@ -46,8 +38,8 @@ class Session implements ISession {
 
   /** @return void */
   public function destroy() {
-    $this->eol= time() - 1;
-    $this->new= false;
+    $this->expires= time() - 1;
+    $this->detached= false;
     $this->sessions->gc();
   }
 
@@ -60,7 +52,7 @@ class Session implements ISession {
    * @throws web.session.SessionInvalid
    */
   public function register($name, $value) {
-    if (time() >= $this->eol) {
+    if (time() >= $this->expires) {
       throw new SessionInvalid($this->id);
     }
     $this->values[$name]= [$value];
@@ -75,7 +67,7 @@ class Session implements ISession {
    * @throws web.session.SessionInvalid
    */
   public function value($name, $default= null) {
-    if (time() >= $this->eol) {
+    if (time() >= $this->expires) {
       throw new SessionInvalid($this->id);
     }
     return $this->values[$name][0] ?? $default;
@@ -89,7 +81,7 @@ class Session implements ISession {
    * @throws web.session.SessionInvalid
    */
   public function remove($name) {
-    if (time() >= $this->eol) {
+    if (time() >= $this->expires) {
       throw new SessionInvalid($this->id);
     }
 
@@ -108,24 +100,5 @@ class Session implements ISession {
    */
   public function close() {
     // NOOP
-  }
-
-  /**
-   * Closes and transmits this session to the response
-   *
-   * @param  web.Response $response
-   * @return void
-   */
-  public function transmit($response) {
-    if ($this->new) {
-      $this->sessions->attach($this, $response);
-      $this->new= false;
-      // Fall through, writing session data
-    } else if (time() >= $this->eol) {
-      $this->sessions->detach($this, $response);
-      return;
-    }
-
-    $this->close();
   }
 }

--- a/src/main/php/web/session/testing/Session.class.php
+++ b/src/main/php/web/session/testing/Session.class.php
@@ -5,7 +5,7 @@ use web\session\{ISession, SessionInvalid};
 /**
  * A testing session
  *
- * @see   xp://web.session.ForTesting
+ * @see   web.session.ForTesting
  */
 class Session implements ISession {
   private $sessions, $new, $id, $eol;
@@ -31,6 +31,9 @@ class Session implements ISession {
 
   /** @return bool */
   public function valid() { return time() < $this->eol; }
+
+  /** @return int */
+  public function remaining($time= null) { return $this->eol - ($time ?? time()); }
 
   /**
    * Returns all session keys

--- a/src/main/php/web/session/testing/Session.class.php
+++ b/src/main/php/web/session/testing/Session.class.php
@@ -33,7 +33,7 @@ class Session implements ISession {
   public function valid() { return time() < $this->eol; }
 
   /** @return int */
-  public function remaining($time= null) { return $this->eol - ($time ?? time()); }
+  public function expires() { return $this->eol; }
 
   /**
    * Returns all session keys

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace web\session\unittest;
 
-use test\Assert;
-use test\{Expect, Test, TestCase};
+use test\{Assert, Expect, Test, Values};
 use web\io\{TestInput, TestOutput};
 use web\session\{Cookies, ISession, SessionInvalid};
 use web\{Request, Response};
@@ -42,10 +41,16 @@ abstract class SessionsTest {
     Assert::equals('SESS', $sessions->named('SESS')->name());
   }
 
-  #[Test]
-  public function lasting() {
-    $sessions= $this->fixture();
-    Assert::equals(43200, $sessions->lasting(43200)->duration());
+  #[Test, Values([3600, 43200])]
+  public function lasting($duration) {
+    $sessions= $this->fixture()->lasting($duration);
+    Assert::equals($duration, $sessions->duration());
+  }
+
+  #[Test, Values([3600, 43200])]
+  public function remaining_time($duration) {
+    $sessions= $this->fixture()->lasting($duration);
+    Assert::equals($sessions->duration(), $sessions->create()->remaining());
   }
 
   #[Test]
@@ -212,6 +217,13 @@ abstract class SessionsTest {
     $session= $this->fixture()->create();
     $session->destroy();
     Assert::false($session->valid());
+  }
+
+  #[Test]
+  public function no_remaing_time_after_having_been_destroyed() {
+    $session= $this->fixture()->create();
+    $session->destroy();
+    Assert::true($session->remaining() < 0);
   }
 
   #[Test, Expect(SessionInvalid::class)]

--- a/src/test/php/web/session/unittest/SessionsTest.class.php
+++ b/src/test/php/web/session/unittest/SessionsTest.class.php
@@ -48,9 +48,9 @@ abstract class SessionsTest {
   }
 
   #[Test, Values([3600, 43200])]
-  public function remaining_time($duration) {
+  public function expires($duration) {
     $sessions= $this->fixture()->lasting($duration);
-    Assert::equals($sessions->duration(), $sessions->create()->remaining());
+    Assert::equals(time() + $sessions->duration(), $sessions->create()->expires());
   }
 
   #[Test]
@@ -220,10 +220,10 @@ abstract class SessionsTest {
   }
 
   #[Test]
-  public function no_remaing_time_after_having_been_destroyed() {
+  public function expiry_past_after_having_been_destroyed() {
     $session= $this->fixture()->create();
     $session->destroy();
-    Assert::true($session->remaining() < 0);
+    Assert::true($session->expires() < time());
   }
 
   #[Test, Expect(SessionInvalid::class)]


### PR DESCRIPTION
```php
use web\session\InFileSystem;

$sessions= new InFileSystem()->lasting(3600);
$session= $sessions->create();

$session->expires(); // time() + 3600
```

⚠️ This PR doesn't touch the `ISession` interface for obvious BC problems! Instead, it introduced a new `web.session.Persistence` base class with this method readily implemented. It supersedes the interface while implementing it for the time being.